### PR TITLE
Do not change directory when running docker-compose

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -4,20 +4,20 @@ if which greadlink > /dev/null 2>&1; then
     alias readlink=greadlink
 fi
 
-cd "$(dirname "$(dirname "$(readlink -f "$0")")../")"
+projectDir="$(dirname "$(dirname "$(readlink -f "$0")")../")"
 
 # we need some configuration
 if [ -e .env ]; then
-    . "$(pwd)/.env"
+    . "$projectDir/.env"
 elif [ -e .env-sample ]; then
-    . "$(pwd)/.env-sample"
+    . "$projectDir/.env-sample"
 else
     echo "no config found"
     exit 1
 fi
 
-. share/init
+. $projectDir/share/init
 
 projectName=$(echo $BASEHOST | sed 's/[^a-zA-Z]//g')
 
-docker-compose -f "$COMPOSE_FILE" -p "$projectName" "$@"
+docker-compose -f "$projectDir/$COMPOSE_FILE" -p "$projectName" "$@"


### PR DESCRIPTION
This way, when using the environment and you start the docker
containers, opening a new window will stay in the current directory,
instead of opening in the compose directory